### PR TITLE
docs: pull git submodule before build

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ To build from source, run the following commands:
 
 ```sh
 git clone https://github.com/Myriad-Dreamin/typst-book.git
+git submodule update --recursive --init
 cargo run --bin typst-book-build
 # optional: install it globally
 cargo install --path ./cli

--- a/cli/src/project.rs
+++ b/cli/src/project.rs
@@ -67,7 +67,7 @@ impl Project {
         }
 
         if args.workspace.is_empty() {
-            args.workspace = args.dir.clone();
+            args.workspace.clone_from(&args.dir);
         }
 
         let tr = TypstRenderer::new(args);
@@ -101,11 +101,11 @@ impl Project {
         }
 
         if final_dest_dir.is_empty() {
-            final_dest_dir = "dist".to_owned();
+            "dist".clone_into(&mut final_dest_dir);
         }
 
         proj.tr.fix_dest_dir(Path::new(&final_dest_dir));
-        proj.dest_dir = proj.tr.dest_dir.clone();
+        proj.dest_dir.clone_from(&proj.tr.dest_dir);
 
         Ok(proj)
     }

--- a/cli/src/render/html.rs
+++ b/cli/src/render/html.rs
@@ -150,7 +150,7 @@ impl HelperDef for RenderToc {
 
         for item in chapters {
             // Spacer
-            if item.get("spacer").is_some() {
+            if item.contains_key("spacer") {
                 out.write("<li class=\"spacer\"></li>")?;
                 continue;
             }
@@ -189,7 +189,7 @@ impl HelperDef for RenderToc {
                     write_li_open_tag(out, is_expanded, false)?;
                 }
                 Ordering::Equal => {
-                    write_li_open_tag(out, is_expanded, item.get("section").is_none())?;
+                    write_li_open_tag(out, is_expanded, !item.contains_key("section"))?;
                 }
             }
 

--- a/github-pages/docs/guide/installation.typ
+++ b/github-pages/docs/guide/installation.typ
@@ -34,6 +34,7 @@ To build from source, run the following commands (note: it depends on `yarn` to 
 
 ```sh
 git clone https://github.com/Myriad-Dreamin/typst-book.git
+git submodule update --recursive --init
 cargo run --bin typst-book-build
 # optional: install it globally
 cargo install --path ./cli


### PR DESCRIPTION
The submodule `assets` needs to be set before cargo build.