### PR TITLE
feat: initial static assets support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +652,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,7 +909,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3486,6 +3505,8 @@ version = "0.3.1-rc4"
 dependencies = [
  "anyhow",
  "async-stream",
+ "base64 0.22.1",
+ "blake3",
  "clap",
  "clap_complete",
  "clap_complete_fig",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,8 @@ bench = false
 doc = false
 
 [dependencies]
-
+base64 = "0.22"
+blake3 = "1.8"
 clap.workspace = true
 clap_complete.workspace = true
 clap_complete_fig.workspace = true

--- a/cli/src/book.rs
+++ b/cli/src/book.rs
@@ -1,10 +1,2 @@
 pub mod meta;
 pub mod outline;
-
-use reflexo_typst::ImmutStr;
-use typst::ecow::EcoString;
-
-pub struct ChapterItem {
-    pub title: EcoString,
-    pub path: Option<ImmutStr>,
-}

--- a/cli/src/book/meta.rs
+++ b/cli/src/book/meta.rs
@@ -134,3 +134,25 @@ impl Default for Search {
         }
     }
 }
+
+/// Static asset to be copied to output directory
+#[derive(Debug, Deserialize)]
+pub struct StaticAsset {
+    pub src: RawAssetSource,
+    /// Destination path relative to dest-dir
+    pub dest: String,
+    /// Asset type hint (css, js, font, image, etc.)
+    #[serde(rename = "type")]
+    pub asset_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RawAssetSource {
+    /// Source path relative to workspace root
+    Path(String),
+    /// Direct content text (UTF-8)
+    Text(String),
+    /// Direct content bytes (in base64)
+    Bytes(String),
+}

--- a/cli/src/project.rs
+++ b/cli/src/project.rs
@@ -1,3 +1,4 @@
+pub mod assets;
 mod compile;
 mod meta;
 mod release;
@@ -7,16 +8,15 @@ use core::fmt;
 use std::path::PathBuf;
 
 use ::typst::ecow::EcoString;
+use reflexo_typst::ImmutStr;
 use serde::{Deserialize, Serialize};
 
 pub(crate) use self::watch::{ServeEvent, WatchSignal};
 use crate::{
     args::{CompileArgs, MetaSource, RenderMode},
-    book::{
-        meta::{BookMeta, BuildMeta},
-        ChapterItem,
-    },
+    book::meta::{BookMeta, BuildMeta},
     error::prelude::*,
+    project::assets::AssetManager,
     render::{SearchRenderer, TypstRenderer},
     utils::{create_dirs, write_file},
 };
@@ -56,10 +56,16 @@ pub struct Project {
     pub book_meta: BookMeta,
     pub build_meta: Option<BuildMeta>,
     pub chapters: Vec<ChapterItem>,
+    pub assets: AssetManager,
 
     pub dest_dir: PathBuf,
     pub args: CompileArgs,
     pub meta_source: MetaSource,
+}
+
+pub struct ChapterItem {
+    pub title: EcoString,
+    pub path: Option<ImmutStr>,
 }
 
 impl Project {
@@ -81,6 +87,7 @@ impl Project {
             book_meta: Default::default(),
             build_meta: None,
             chapters: vec![],
+            assets: AssetManager::new(),
         };
 
         release::release_builtin_packages(&mut proj.tr.universe_mut().snapshot());

--- a/cli/src/project/assets.rs
+++ b/cli/src/project/assets.rs
@@ -1,0 +1,257 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fs::{self, File},
+    io::{self, Read, Write},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+
+use blake3::Hasher;
+
+use crate::{
+    error::prelude::*,
+    utils::{create_dirs, make_absolute_from},
+};
+
+/// Static asset to be copied to output directory
+#[derive(Debug, Clone, PartialEq)]
+pub struct AssetInput {
+    pub src: AssetSource,
+    /// Destination path (made absolute later)
+    pub dest: String,
+    /// Asset type hint (css, js, font, image, etc.)
+    pub asset_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AssetSource {
+    /// Source path (absolute)
+    Path(PathBuf),
+    /// Direct content bytes
+    Bytes(Vec<u8>),
+}
+
+/// Result about what happened for an asset submission.
+#[derive(Debug)]
+pub struct ProcessedAsset {
+    pub dest: PathBuf,
+    pub written: bool, // true if the file was written/overwritten on disk
+}
+
+/// In-memory record for a destination.
+#[derive(Clone, Debug)]
+struct DestRecord {
+    hash: String,
+    owner: Option<String>, // page id that created/owns it in this run (None = unknown / preexisting)
+                           // dest: PathBuf,
+}
+// TODO: the dest can change at runtime, so we may need to track more info per dest.
+
+/// Thread-safe manager for parallel page compilers.
+#[derive(Clone, Default)]
+pub struct AssetManager(Arc<Mutex<AssetManagerInner>>);
+
+/// Shared inner state protected by Mutex.
+#[derive(Default)]
+struct AssetManagerInner {
+    dest_map: HashMap<PathBuf, DestRecord>,
+    page_dependencies: HashMap<String, HashSet<PathBuf>>, // page_id -> list of dest paths. not used yet.
+}
+
+impl AssetManager {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Submit a page's assets. Can be called concurrently from many threads.
+    /// - For each asset: compute its hash, then under lock apply the rules:
+    ///   * same-page update -> overwrite allowed
+    ///   * different-page different-hash -> Conflict error
+    ///   * identical-hash anywhere -> reuse/skip write
+    ///
+    /// Returns ProcessedAsset list (same order as inputs).
+    pub fn submit_assets(
+        &self,
+        page_id: &str,
+        inputs: &[AssetInput],
+        dist_dir: &Path,
+    ) -> Result<()> {
+        // 1) compute hashes before locking
+        let mut items: Vec<(AssetInput, String)> = Vec::with_capacity(inputs.len());
+        for input in inputs.iter() {
+            let hash = compute_hash_of_source(&input.src).context("compute_hash_of_file")?;
+            items.push((input.clone(), hash));
+        }
+        log::info!("Submitting {} assets for page {}", items.len(), page_id);
+
+        // 2) lock and apply rules & write under lock (keeping operations as short as practical)
+        // Alternative (more advanced): reserve under lock, release, perform IO, then re-lock to commit/rollback.
+        // For simplicity and correctness we keep write under the lock here.
+        let mut inner = self.0.lock().unwrap();
+        let inner = &mut *inner;
+
+        create_dirs(dist_dir)?;
+
+        let dest_map = &mut inner.dest_map;
+        let mut dependencies = HashSet::new();
+
+        for (input, hash) in items.into_iter() {
+            let dest_path = make_absolute_from(Path::new(&input.dest), || dist_dir.to_path_buf());
+
+            // validate that dest is within dist_dir
+            if !dest_path.starts_with(dist_dir) {
+                log::warn!(
+                    "Asset destination {dest_path:?} is outside of dist dir {dist_dir:?}, skipping"
+                );
+                continue;
+            }
+            // check that source exists (for Path variant)
+            if let AssetSource::Path(p) = &input.src {
+                if !p.exists() {
+                    log::warn!("Asset source path {p:?} does not exist, skipping");
+                    continue;
+                }
+            }
+
+            dependencies.insert(dest_path.clone());
+
+            // check in-memory record
+            if let Some(rec) = dest_map.get(&dest_path) {
+                if rec.hash == hash {
+                    log::debug!(
+                        "Asset at {dest_path:?} already exists with same hash {hash}, skipping write"
+                    );
+                    // same content => ok, no write
+                    continue;
+                }
+
+                // different content
+                if rec.owner.as_deref() != Some(page_id) {
+                    log::warn!(
+                        "Asset conflict at {dest_path:?}: existing hash {}, new hash {}",
+                        rec.hash,
+                        hash
+                    );
+                    continue;
+                }
+                log::info!(
+                    "Asset at {dest_path:?} being overwritten by same page {page_id}, hash {} -> {}",
+                    rec.hash,
+                    hash
+                );
+                // same page owns it previously -> allow overwrite
+                write_atomic_from_source(&input.src, &dest_path).context("submit create dirs")?;
+                // update record
+                dest_map.insert(
+                    dest_path.clone(),
+                    DestRecord {
+                        hash: hash.clone(),
+                        owner: Some(page_id.to_string()),
+                    },
+                );
+                continue;
+            }
+
+            // no in-memory record: check on-disk
+            if dest_path.exists() {
+                let disk_hash = compute_hash_of_file(&dest_path).context("compute_hash_of_file")?;
+                if disk_hash != hash {
+                    // on-disk content differs => conflict
+                    log::warn!(
+                        "Asset conflict at {dest_path:?}: existing on-disk hash {disk_hash}, new hash {hash}",
+                    );
+                }
+                // file on disk matches -> record with owner = None or optionally claim owner
+                dest_map.insert(
+                    dest_path.clone(),
+                    DestRecord {
+                        hash: disk_hash.clone(),
+                        owner: Some(page_id.to_string()), // claim ownership for this run
+                    },
+                );
+                continue;
+            }
+
+            // dest absent both in memory and on disk -> write and claim
+            log::info!("Writing new asset at {dest_path:?} for page {page_id}, hash {hash}");
+            if let Some(parent) = dest_path.parent() {
+                fs::create_dir_all(parent).context("submit create dirs")?;
+            }
+            write_atomic_from_source(&input.src, &dest_path).context("write_atomic_from_source")?;
+            dest_map.insert(
+                dest_path.clone(),
+                DestRecord {
+                    hash: hash.clone(),
+                    owner: Some(page_id.to_string()),
+                },
+            );
+        }
+
+        log::info!(
+            "Computed {} asset dependencies for page {}",
+            dependencies.len(),
+            page_id
+        );
+
+        // Remove staled dependencies for this page, and update with new ones.
+        if let Some(old_deps) = inner.page_dependencies.get_mut(page_id) {
+            for old_path in old_deps.drain() {
+                if !dependencies.contains(&old_path) {
+                    log::info!("Removing stale asset dependency {old_path:?} for page {page_id}");
+                    let _ = fs::remove_file(&old_path);
+                }
+            }
+        }
+        inner
+            .page_dependencies
+            .insert(page_id.to_string(), dependencies);
+
+        Ok(())
+    }
+}
+
+/// Helper to write source -> final_path atomically.
+fn write_atomic_from_source(src: &AssetSource, final_path: &Path) -> io::Result<()> {
+    let tmp = final_path.with_extension("tmp");
+    let _ = fs::remove_file(&tmp);
+    match src {
+        AssetSource::Path(p) => {
+            fs::copy(p, &tmp)?;
+        }
+        AssetSource::Bytes(b) => {
+            let mut f = File::create(&tmp)?;
+            f.write_all(b)?;
+            f.sync_all()?;
+        }
+    }
+    let _ = fs::remove_file(final_path);
+    fs::rename(&tmp, final_path)?;
+    Ok(())
+}
+
+/// Compute blake3 hash for AssetSource.
+fn compute_hash_of_source(src: &AssetSource) -> io::Result<String> {
+    match src {
+        AssetSource::Path(p) => compute_hash_of_file(p),
+        AssetSource::Bytes(b) => {
+            let mut hasher = Hasher::new();
+            hasher.update(b);
+            Ok(hasher.finalize().to_hex().to_string())
+        }
+    }
+}
+
+/// Compute blake3 hash for a file (streaming).
+fn compute_hash_of_file(path: &Path) -> io::Result<String> {
+    let mut f = File::open(path)?;
+    let mut hasher = Hasher::new();
+    let mut buf = [0u8; 8 * 1024];
+    loop {
+        let n = f.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}

--- a/cli/src/project/watch.rs
+++ b/cli/src/project/watch.rs
@@ -34,6 +34,8 @@ impl Project {
                 }
             });
 
+            // TODO: Add static asset files to watched dependencies
+
             tui_info!("Watching {} files for changes...", deps.len());
             let _ = dep_tx.send(NotifyMessage::SyncDependency(Box::new(deps)));
 

--- a/cli/src/render/typst.rs
+++ b/cli/src/render/typst.rs
@@ -42,10 +42,9 @@ use crate::{
     book::{
         meta::{BookMetaContent, BookMetaElem},
         outline::{outline, Outline, OutlineItem},
-        ChapterItem,
     },
     error::prelude::*,
-    project::ChapterArtifact,
+    project::{ChapterArtifact, ChapterItem},
     render::SearchCtx,
     utils::{
         create_dirs, interner::SpanInternerImpl, make_absolute, make_absolute_from, write_file,

--- a/packages/shiroa/lib.typ
+++ b/packages/shiroa/lib.typ
@@ -22,6 +22,8 @@
 //!   - `cross-link`
 //!   - `plain-text`
 //!   - `media`
+//!   - `external-link`
+//!   - `external-script`
 
 // Part I: Metadata variables and functions
 #import "meta-and-state.typ": *
@@ -32,7 +34,7 @@
 // Part III: Supports
 #import "supports-link.typ" as link-support: cross-link
 #import "supports-text.typ" as text-support: plain-text
-#import "supports-html.typ" as html-support
+#import "supports-html.typ" as html-support: external-link, external-script
 #import "media.typ"
 #import "utils.typ": get-book-meta, get-build-meta
 

--- a/packages/shiroa/supports-html.typ
+++ b/packages/shiroa/supports-html.typ
@@ -33,3 +33,54 @@
 
   body
 }
+
+/// Create a link element for an external stylesheet
+///
+/// References an external CSS file that will be copied to the output directory.
+/// The path should be relative to the output directory (matching the asset's `dest` path).
+///
+/// - href (str): Path to the CSS file relative to output directory
+/// - ..rest: Additional attributes (media, crossorigin, etc.)
+///
+/// Example:
+/// ```typst
+/// #external-link("assets/custom.css")
+/// #external-link("assets/print.css", media: "print")
+/// ```
+#let external-link(href, ..rest) = if is-html-target() and "html" in std {
+  import "sys.typ": x-url-base
+  html.elem("link", attrs: (rel: "stylesheet", href: x-url-base + href, ..rest.named()))
+}
+
+/// Create a script element for an external JavaScript file
+///
+/// References an external JS file that will be copied to the output directory.
+/// The path should be relative to the output directory (matching the asset's `dest` path).
+///
+/// - src (str): Path to the JS file relative to output directory
+/// - ..rest: Additional attributes (defer, async, type, etc.)
+///
+/// Example:
+/// ```typst
+/// #external-script("assets/custom.js")
+/// #external-script("assets/analytics.js", defer: true)
+/// ```
+#let external-script(src, ..rest) = if is-html-target() and "html" in std {
+  import "sys.typ": x-url-base
+  html.elem("script", attrs: (src: x-url-base + src, ..rest.named()))
+}
+
+/// Create a stylesheet metadata entry for inclusion in the output
+///
+/// - body (str, content): Stylesheet content as a string or raw content
+/// - key (str): Key for grouping in the output files (default: "main")
+/// - priority (int): Priority for ordering stylesheets (lower number = higher priority)
+#let stylesheet(body, key: "main", priority: 0) = {
+  let text = if type(body) == str {
+    body
+  } else {
+    assert(type(body) == content, message: "invalid stylesheet content")
+    body.text
+  }
+  [#metadata((text: text, key: key, priority: priority)) <shiroa-stylesheet>]
+}

--- a/packages/shiroa/supports-html.typ
+++ b/packages/shiroa/supports-html.typ
@@ -1,5 +1,6 @@
 
 #import "meta-and-state.typ": is-html-target
+#import "summary.typ": static-asset
 #import "supports-html-internal.typ"
 #let data-url(mime, src) = {
   import "@preview/based:0.2.0": base64
@@ -83,4 +84,26 @@
     body.text
   }
   [#metadata((text: text, key: key, priority: priority)) <shiroa-stylesheet>]
+}
+
+#let extract-html-script(body, dest: none) = {
+  show html.elem.where(tag: "script"): it => {
+    if it.body.has("text") {
+      static-asset(text: it.body.text, dest: dest, type: "js")
+    } else {
+      it
+    }
+  }
+  body
+}
+
+#let extract-html-style(body, dest: none) = {
+  show html.elem.where(tag: "style"): it => {
+    if it.body.has("text") {
+      static-asset(text: it.body.text, dest: dest, type: "css")
+    } else {
+      it
+    }
+  }
+  body
 }

--- a/packages/shiroa/templates.typ
+++ b/packages/shiroa/templates.typ
@@ -108,7 +108,6 @@
   web-theme: "starlight",
   theme-box: none,
 ) = {
-  import "supports-html.typ": add-styles
   let is-starlight-theme = web-theme == "starlight"
   let in-heading = state("shiroa:in-heading", false)
 
@@ -144,19 +143,17 @@
     it
   }
 
-  add-styles(
-    ```css
-    .inline-equation {
-      display: inline-block;
-      width: fit-content;
-    }
-    .block-equation {
-      display: grid;
-      place-items: center;
-      overflow-x: auto;
-    }
-    ```,
-  )
+  stylesheet(```css
+  .inline-equation {
+    display: inline-block;
+    width: fit-content;
+  }
+  .block-equation {
+    display: grid;
+    place-items: center;
+    overflow-x: auto;
+  }
+  ```)
   body
 }
 
@@ -296,7 +293,10 @@
   mdbook: "@preview/shiroa-mdbook:0.3.1",
 ) = {
   // Prepares description
-  assert(type(description) == str or description == auto, message: "description must be a string or auto")
+  assert(
+    type(description) == str or description == auto,
+    message: "description must be a string or auto",
+  )
   let description = if description != auto { description } else {
     let desc = plain-text(plain-body, limit: 512).trim()
     let desc_chars = desc.clusters()

--- a/packages/shiroa/templates.typ
+++ b/packages/shiroa/templates.typ
@@ -211,7 +211,7 @@
     numbering: false,
   )
 
-  let init-with-theme((code-extra-colors, is-dark)) = if is-dark {
+  let init-zebraw-with-theme((code-extra-colors, is-dark)) = if is-dark {
     zebraw-init.with(
       // should vary by theme
       background-color: if code-extra-colors.bg != none {
@@ -230,6 +230,13 @@
       },
       ..zebraw-commons,
     )
+  }
+
+  let init-with-theme(args) = it => {
+    show: extract-html-style.with(dest: "assets/zebraw.css")
+    show: extract-html-script.with(dest: "assets/zebraw-clipboard.js")
+    show: init-zebraw-with-theme(args)
+    it
   }
 
   context if shiroa-sys-target() != "html" {

--- a/themes/mdbook/lib.typ
+++ b/themes/mdbook/lib.typ
@@ -20,7 +20,10 @@
   social-links: social-links,
   right-group: none,
 ) = {
-  import "@preview/shiroa:0.3.1": get-book-meta, is-html-target, paged-load-trampoline, x-current, x-target, x-url-base
+  import "@preview/shiroa:0.3.1": (
+    external-link, external-script, get-book-meta, is-html-target, paged-load-trampoline,
+    query-static-assets, x-current, x-target, x-url-base,
+  )
   import "mod.typ": inline-assets, replace-raw
   import "html.typ": a, div, meta
   import "icons.typ": builtin-icon
@@ -53,11 +56,22 @@
     context html.elem("title", meta-title(title, site-title()))
     // <meta description>
     if description != none { meta(name: "description", content: description) }
+    // Static asset references
+    context for asset-meta in query-static-assets() {
+      let asset = asset-meta.value
+      if asset.type == "css" {
+        external-link(asset.dest)
+      } else if asset.type == "js" {
+        external-script(asset.dest)
+      }
+    }
   })
 
   show: set-slot("main-title", html.elem("h1", attrs: (class: "menu-title"), title))
   // todo: determine a good name of html wrapper
-  show: set-slot("main-content", if x-target.starts-with("html-wrapper") { trampoline } else { body })
+  show: set-slot("main-content", if x-target.starts-with("html-wrapper") { trampoline } else {
+    body
+  })
 
   // show: set-slot("header", include "page-header.typ")
   show: set-slot("sl:book-meta", book + inline-assets(extra-assets.join()))

--- a/themes/starlight/content-panel.typ
+++ b/themes/starlight/content-panel.typ
@@ -7,28 +7,26 @@
   div(class: "sl-container", virt-slot("body"))
 })
 
-#add-styles(
-  ```css
-  @layer starlight.core {
-    .content-panel {
-      padding: 1.5rem var(--sl-content-pad-x);
-    }
-    .content-panel + .content-panel {
-      border-top: 1px solid var(--sl-color-hairline);
-    }
+#stylesheet(key: "starlight", ```css
+@layer starlight.core {
+  .content-panel {
+    padding: 1.5rem var(--sl-content-pad-x);
+  }
+  .content-panel + .content-panel {
+    border-top: 1px solid var(--sl-color-hairline);
+  }
+  .sl-container.content-panel {
+    max-width: var(--sl-content-width);
+  }
+
+  .sl-container.content-panel > :global(* + *) {
+    margin-top: 1.5rem;
+  }
+
+  @media (min-width: 72rem) {
     .sl-container.content-panel {
-      max-width: var(--sl-content-width);
-    }
-
-    .sl-container.content-panel > :global(* + *) {
-      margin-top: 1.5rem;
-    }
-
-    @media (min-width: 72rem) {
-      .sl-container.content-panel {
-        margin-inline: var(--sl-content-margin-inline, auto);
-      }
+      margin-inline: var(--sl-content-margin-inline, auto);
     }
   }
-  ```,
-)
+}
+```)

--- a/themes/starlight/head.typ
+++ b/themes/starlight/head.typ
@@ -14,13 +14,17 @@
   virt-slot("sa:head-meta")
   meta(name: "generator", content: "Shiroa")
 
+  stylesheet(key: "starlight", {
+    ```css @layer starlight.base, starlight.reset, starlight.core, starlight.content, starlight.components, starlight.utils;```.text
+    read("styles/props.css")
+    read("styles/reset.css")
+    read("styles/asides.css")
+    read("styles/markdown.css")
+    read("styles/utils.css")
+  })
+
   inline-assets(context (
-    ```css @layer starlight.base, starlight.reset, starlight.core, starlight.content, starlight.components, starlight.utils;```,
-    raw(lang: "css", read("styles/props.css")),
-    raw(lang: "css", read("styles/reset.css")),
-    raw(lang: "css", read("styles/asides.css")),
-    raw(lang: "css", read("styles/markdown.css")),
-    raw(lang: "css", read("styles/utils.css")),
+    // ```css @layer starlight.base, starlight.reset, starlight.core, starlight.content, starlight.components, starlight.utils;```,
     if is-debug {
       raw(lang: "js", read("/assets/artifacts/elasticlunr.min.js"))
       raw(lang: "js", read("/assets/artifacts/mark.min.js"))

--- a/themes/starlight/index.typ
+++ b/themes/starlight/index.typ
@@ -17,48 +17,46 @@
   })
 })
 
-#add-styles(
-  ```css
-  @layer starlight.core {
-    .main-pane {
-      isolation: isolate;
+#stylesheet(key: "starlight", ```css
+@layer starlight.core {
+  .main-pane {
+    isolation: isolate;
+  }
+
+  @media (min-width: 72rem) {
+    .right-sidebar-container {
+      order: 2;
+      position: relative;
+      width: calc(
+        var(--sl-sidebar-width) + (100% - var(--sl-content-width) - var(--sl-sidebar-width)) / 2
+      );
     }
 
-    @media (min-width: 72rem) {
-      .right-sidebar-container {
-        order: 2;
-        position: relative;
-        width: calc(
-          var(--sl-sidebar-width) + (100% - var(--sl-content-width) - var(--sl-sidebar-width)) / 2
-        );
-      }
+    .right-sidebar {
+      position: fixed;
+      top: 0;
+      border-inline-start: 1px solid var(--sl-color-hairline);
+      padding-top: var(--sl-nav-height);
+      width: 100%;
+      height: 100vh;
+      overflow-y: auto;
+      scrollbar-width: none;
+    }
 
-      .right-sidebar {
-        position: fixed;
-        top: 0;
-        border-inline-start: 1px solid var(--sl-color-hairline);
-        padding-top: var(--sl-nav-height);
-        width: 100%;
-        height: 100vh;
-        overflow-y: auto;
-        scrollbar-width: none;
-      }
+    .main-pane {
+      width: 100%;
+    }
 
-      .main-pane {
-        width: 100%;
-      }
+    :root[data-has-sidebar][data-has-toc] .main-pane {
+      --sl-content-margin-inline: auto 0;
 
-      :root[data-has-sidebar][data-has-toc] .main-pane {
-        --sl-content-margin-inline: auto 0;
-
-        order: 1;
-        width: calc(
-          var(--sl-content-width) + (100% - var(--sl-content-width) - var(--sl-sidebar-width)) / 2
-        );
-      }
+      order: 1;
+      width: calc(
+        var(--sl-content-width) + (100% - var(--sl-content-width) - var(--sl-sidebar-width)) / 2
+      );
     }
   }
-  ```,
-)
+}
+```)
 
 // todo: global([data-has-sidebar][data-has-toc]) v.s. :root[data-has-sidebar][data-has-toc]

--- a/themes/starlight/lib.typ
+++ b/themes/starlight/lib.typ
@@ -26,7 +26,10 @@
   },
   right-group: none,
 ) = {
-  import "@preview/shiroa:0.3.1": get-book-meta, is-html-target, paged-load-trampoline, plain-text, x-current, x-target
+  import "@preview/shiroa:0.3.1": (
+    external-link, external-script, get-book-meta, is-html-target, paged-load-trampoline,
+    plain-text, query-static-assets, static-asset, x-current, x-target,
+  )
   import "html.typ": inline-assets, meta, span
   import "mod.typ": replace-raw
 
@@ -35,6 +38,37 @@
       "Starlight theme is only available with `--mode=static-html`. Either change theme to mdbook or turn mode into `static-html`.",
     )
     return body
+  }
+
+  let static-assets-ref = {
+    context for asset-meta in query-static-assets() {
+      let asset = asset-meta.value
+      if asset.type == "css" {
+        external-link(asset.dest)
+      } else if asset.type == "js" {
+        external-script(asset.dest)
+      }
+    }
+    context {
+      let stylesheets = query(<shiroa-stylesheet>)
+      if stylesheets.len() > 0 {
+        // group by key. combine stylesheets with the same key into one .css file.
+        let grouped = (:)
+        for m in stylesheets {
+          let s = m.value
+          if s.key not in grouped {
+            grouped.insert(s.key, (s.text,))
+          } else {
+            grouped.at(s.key).push(s.text)
+          }
+        }
+        for (k, v) in grouped {
+          let path = "assets/" + k + ".css"
+          external-link(path)
+          static-asset(text: v.join("\n"), dest: path, type: "css")
+        }
+      }
+    }
   }
 
   let trampoline = paged-load-trampoline()
@@ -55,7 +89,10 @@
     let github-link = it.at("repository", default: none)
     let discord-link = it.at("discord", default: none)
 
-    right-group-item(class: "social-icons", social-icons(social-links(github: github-link, discord: discord-link)))
+    right-group-item(class: "social-icons", social-icons(social-links(
+      github: github-link,
+      discord: discord-link,
+    )))
     right-group-item(include "theme-select.typ")
     right-group-item(class: "md:sl-hidden", include "page-sidebar-mobile.typ")
   })
@@ -65,18 +102,28 @@
     context html.elem("title", meta-title(title, site-title()))
     // <meta description>
     if description != none { meta(name: "description", content: description) }
+    // Static asset references
+    static-assets-ref
   })
 
   show: set-slot("main-title", html.elem("h1", title))
   // todo: determine a good name of html wrapper
-  show: set-slot("main-content", if x-target.starts-with("html-wrapper") { trampoline } else { body })
+  show: set-slot("main-content", if x-target.starts-with("html-wrapper") {
+    trampoline
+  } else {
+    body
+  })
 
   show: set-slot("header", include "page-header.typ")
   show: set-slot("site-title", context span(class: "site-title", site-title()))
   show: set-slot("sl:book-meta", book + inline-assets(extra-assets.join()))
   show: set-slot("sl:search", if enable-search { include "site-search.typ" })
   show: set-slot("sl:search-results", if enable-search { include "site-search-results.typ" })
-  show: set-slot("sl:right-group", if right-group != none { right-group } else { default-right-group() })
+  show: set-slot("sl:right-group", if right-group != none {
+    right-group
+  } else {
+    default-right-group()
+  })
 
   // div(class: "sl-flex social-icons", virt-slot("social-icons")),
   // // virt-slot("theme-select"),

--- a/themes/starlight/mod.typ
+++ b/themes/starlight/mod.typ
@@ -1,8 +1,10 @@
 
 
 #import "html.typ": *
-#import "@preview/shiroa:0.3.1": plain-text, templates
-#import templates: get-label-disambiguator, label-disambiguator, make-unique-label, static-heading-link
+#import "@preview/shiroa:0.3.1": plain-text, static-asset, templates
+#import templates: (
+  get-label-disambiguator, label-disambiguator, make-unique-label, static-heading-link,
+)
 
 #let has-toc = true;
 

--- a/themes/starlight/page-header.typ
+++ b/themes/starlight/page-header.typ
@@ -1,7 +1,10 @@
 
 #import "mod.typ": *
 
-#let right-group-item(body, class: none) = div(class: if class != none { class + " " } + "right-group sl-flex", body)
+#let right-group-item(body, class: none) = div(
+  class: if class != none { class + " " } + "right-group sl-flex",
+  body,
+)
 
 // ---
 
@@ -11,72 +14,70 @@
   div(class: "sl-flex", virt-slot("sl:right-group"))
 })
 
-#add-styles(
-  ```css
-  @layer starlight.core {
+#stylesheet(key: "starlight", ```css
+@layer starlight.core {
+  .header {
+    display: flex;
+    gap: var(--sl-nav-gap);
+    justify-content: space-between;
+    align-items: center;
+    height: 100%;
+  }
+
+  .title-wrapper {
+    /* Prevent long titles overflowing and covering the search and menu buttons on narrow viewports. */
+    overflow: clip;
+    /* Avoid clipping focus ring around link inside title wrapper. */
+    padding: 0.25rem;
+    margin: -0.25rem;
+    min-width: 0;
+  }
+
+  .right-group,
+  .social-icons {
+    align-items: center;
+  }
+  .social-icons {
+    gap: 1rem;
+  }
+  .right-group +
+  .right-group::before {
+    content: '';
+    margin: 0 0.7rem;
+    height: 2rem;
+    border-inline-end: 1px solid var(--sl-color-gray-5);
+  }
+
+  @media (min-width: 50rem) {
+    :global(:root[data-has-sidebar]) {
+      --__sidebar-pad: calc(2 * var(--sl-nav-pad-x));
+    }
+    :global(:root:not([data-has-toc])) {
+      --__toc-width: 0rem;
+    }
     .header {
-      display: flex;
-      gap: var(--sl-nav-gap);
-      justify-content: space-between;
-      align-items: center;
-      height: 100%;
-    }
-
-    .title-wrapper {
-      /* Prevent long titles overflowing and covering the search and menu buttons on narrow viewports. */
-      overflow: clip;
-      /* Avoid clipping focus ring around link inside title wrapper. */
-      padding: 0.25rem;
-      margin: -0.25rem;
-      min-width: 0;
-    }
-
-    .right-group,
-    .social-icons {
-      align-items: center;
-    }
-    .social-icons {
-      gap: 1rem;
-    }
-    .right-group +
-    .right-group::before {
-      content: '';
-      margin: 0 0.7rem;
-      height: 2rem;
-      border-inline-end: 1px solid var(--sl-color-gray-5);
-    }
-
-    @media (min-width: 50rem) {
-      :global(:root[data-has-sidebar]) {
-        --__sidebar-pad: calc(2 * var(--sl-nav-pad-x));
-      }
-      :global(:root:not([data-has-toc])) {
-        --__toc-width: 0rem;
-      }
-      .header {
-        --__sidebar-width: max(0rem, var(--sl-content-inline-start, 0rem) - var(--sl-nav-pad-x));
-        --__main-column-fr: calc(
-          (
-              100% + var(--__sidebar-pad, 0rem) - var(--__toc-width, var(--sl-sidebar-width)) -
-                (2 * var(--__toc-width, var(--sl-nav-pad-x))) - var(--sl-content-inline-start, 0rem) -
-                var(--sl-content-width)
-            ) / 2
-        );
-        display: grid;
-        grid-template-columns:
-        /* 1 (site title): runs up until the main content column’s left edge or the width of the title, whichever is the largest  */
-          minmax(
-            calc(var(--__sidebar-width) + max(0rem, var(--__main-column-fr) - var(--sl-nav-gap))),
-            auto
-          )
-          /* 2 (search box): all free space that is available. */
-          1fr
-          /* 3 (right items): use the space that these need. */
-          auto;
-        align-content: center;
-      }
+      --__sidebar-width: max(0rem, var(--sl-content-inline-start, 0rem) - var(--sl-nav-pad-x));
+      --__main-column-fr: calc(
+        (
+            100% + var(--__sidebar-pad, 0rem) - var(--__toc-width, var(--sl-sidebar-width)) -
+              (2 * var(--__toc-width, var(--sl-nav-pad-x))) - var(--sl-content-inline-start, 0rem) -
+              var(--sl-content-width)
+          ) / 2
+      );
+      display: grid;
+      grid-template-columns:
+      /* 1 (site title): runs up until the main content column’s left edge or the width of the title, whichever is the largest  */
+        minmax(
+          calc(var(--__sidebar-width) + max(0rem, var(--__main-column-fr) - var(--sl-nav-gap))),
+          auto
+        )
+        /* 2 (search box): all free space that is available. */
+        1fr
+        /* 3 (right items): use the space that these need. */
+        auto;
+      align-content: center;
     }
   }
-  ```,
-)
+}
+```)
 

--- a/themes/starlight/page-right-sidebar.typ
+++ b/themes/starlight/page-right-sidebar.typ
@@ -19,35 +19,33 @@
   })
 })
 
-#add-styles(
-  ```css
-  @layer starlight.core {
+#stylesheet(key: "starlight", ```css
+@layer starlight.core {
+  .sl-container.page-sidebar {
+    width: calc(var(--sl-sidebar-width) - 2 * var(--sl-sidebar-pad-x));
+  }
+  .right-sidebar-panel {
+    padding: 1rem var(--sl-sidebar-pad-x);
+  }
+  .right-sidebar-panel h2 {
+    color: var(--sl-color-white);
+    font-size: var(--sl-text-h5);
+    font-weight: 600;
+    line-height: var(--sl-line-height-headings);
+    margin: 0;
+    margin-bottom: 0.5rem;
+  }
+  @media (min-width: 72rem) {
     .sl-container.page-sidebar {
-      width: calc(var(--sl-sidebar-width) - 2 * var(--sl-sidebar-pad-x));
-    }
-    .right-sidebar-panel {
-      padding: 1rem var(--sl-sidebar-pad-x);
-    }
-    .right-sidebar-panel h2 {
-      color: var(--sl-color-white);
-      font-size: var(--sl-text-h5);
-      font-weight: 600;
-      line-height: var(--sl-line-height-headings);
-      margin: 0;
-      margin-bottom: 0.5rem;
-    }
-    @media (min-width: 72rem) {
-      .sl-container.page-sidebar {
-        max-width: calc(
+      max-width: calc(
+        (
           (
-            (
-                100vw - var(--sl-sidebar-width) - 2 * var(--sl-content-pad-x) - 2 *
-                  var(--sl-sidebar-pad-x)
-              ) * 0.25 /* MAGIC NUMBER 🥲 */
-          )
-        );
-      }
+              100vw - var(--sl-sidebar-width) - 2 * var(--sl-content-pad-x) - 2 *
+                var(--sl-sidebar-pad-x)
+            ) * 0.25 /* MAGIC NUMBER 🥲 */
+        )
+      );
     }
   }
-  ```,
-)
+}
+```)

--- a/themes/starlight/page-sidebar-mobile.typ
+++ b/themes/starlight/page-sidebar-mobile.typ
@@ -30,23 +30,21 @@
   }
 ]
 
-#add-styles(
-  ```css
-  #sidebar-mobile-toggle[aria-expanded="true"] #sidebar-open {
-    display: none;
-  }
-  #sidebar-mobile-toggle[aria-expanded="false"] #sidebar-close {
-    display: none;
-  }
+#stylesheet(key: "starlight", ```css
+#sidebar-mobile-toggle[aria-expanded="true"] #sidebar-open {
+  display: none;
+}
+#sidebar-mobile-toggle[aria-expanded="false"] #sidebar-close {
+  display: none;
+}
 
-  .sidebar-toggle-button {
-    background: none;
-    border: none;
-    padding: 0.5em;
-    margin: -0.2em;
-  }
-  .sidebar-toggle-button:hover {
-    opacity: 0.66;
-  }
-  ```,
-)
+.sidebar-toggle-button {
+  background: none;
+  border: none;
+  padding: 0.5em;
+  margin: -0.2em;
+}
+.sidebar-toggle-button:hover {
+  opacity: 0.66;
+}
+```)

--- a/themes/starlight/page-sidebar.typ
+++ b/themes/starlight/page-sidebar.typ
@@ -101,84 +101,82 @@ this.parentElement.classList.toggle("open");
   }
 }
 
-#add-styles(
-  ```css
-  .sidebar-content {
-    --sl-sidebar-item-padding-inline: 0.5rem;
-  }
-  .sidebar-content ul > li {
-    padding: 0;
-  }
-  .sidebar-content .sidebar-part li {
-    margin-inline-start: var(--sl-sidebar-item-padding-inline);
-    border-inline-start: 1px solid var(--sl-color-hairline-light);
-    padding-inline-start: var(--sl-sidebar-item-padding-inline);
-  }
+#stylesheet(key: "starlight", ```css
+.sidebar-content {
+  --sl-sidebar-item-padding-inline: 0.5rem;
+}
+.sidebar-content ul > li {
+  padding: 0;
+}
+.sidebar-content .sidebar-part li {
+  margin-inline-start: var(--sl-sidebar-item-padding-inline);
+  border-inline-start: 1px solid var(--sl-color-hairline-light);
+  padding-inline-start: var(--sl-sidebar-item-padding-inline);
+}
 
-  .sidebar-part-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: .2em var(--sl-sidebar-item-padding-inline);
-    background-color: var(--sl-color-gray-7);
-    line-height: 1.4;
-    cursor: pointer;
-  }
+.sidebar-part-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: .2em var(--sl-sidebar-item-padding-inline);
+  background-color: var(--sl-color-gray-7);
+  line-height: 1.4;
+  cursor: pointer;
+}
 
-  .sidebar-part-caret {
-    transition: transform 0.2s ease-in-out;
-    flex-shrink: 0;
-    font-size: 1.25rem;
-  }
-  .sidebar-part.open > .sidebar-part-header .sidebar-part-caret {
-    transform: rotateZ(90deg);
-  }
-  .sidebar-part.open > .sidebar-part-chapters {
-    display: block;
-  }
-  .sidebar-part-chapters {
-    display: none;
-  }
+.sidebar-part-caret {
+  transition: transform 0.2s ease-in-out;
+  flex-shrink: 0;
+  font-size: 1.25rem;
+}
+.sidebar-part.open > .sidebar-part-header .sidebar-part-caret {
+  transform: rotateZ(90deg);
+}
+.sidebar-part.open > .sidebar-part-chapters {
+  display: block;
+}
+.sidebar-part-chapters {
+  display: none;
+}
 
-  .sidebar-content ul, .sidebar-content ol {
-    list-style: none;
-    padding: 0;
-  }
-  .sidebar-content li {
-    overflow-wrap: anywhere;
-  }
+.sidebar-content ul, .sidebar-content ol {
+  list-style: none;
+  padding: 0;
+}
+.sidebar-content li {
+  overflow-wrap: anywhere;
+}
 
-  li.sidebar-part {
-    margin-top: 0.5rem;
-    padding: .2em var(--sl-sidebar-item-padding-inline);
-  }
+li.sidebar-part {
+  margin-top: 0.5rem;
+  padding: .2em var(--sl-sidebar-item-padding-inline);
+}
 
-  .sidebar-part-title {
-    font-weight: 600;
-    color: var(--sl-color-white);
-  }
+.sidebar-part-title {
+  font-weight: 600;
+  color: var(--sl-color-white);
+}
 
-  .sidebar-content a {
-    font-size: var(--sl-text-sm);
-    display:block;
-    border-radius: .25rem;
-    text-decoration: none;
-    color: var(--sl-color-gray-2);
-    padding: .3em var(--sl-sidebar-item-padding-inline);
-    line-height: 1.4
-  }
+.sidebar-content a {
+  font-size: var(--sl-text-sm);
+  display:block;
+  border-radius: .25rem;
+  text-decoration: none;
+  color: var(--sl-color-gray-2);
+  padding: .3em var(--sl-sidebar-item-padding-inline);
+  line-height: 1.4
+}
 
-  .sidebar-content a:hover,
-  .sidebar-content a:focus {
-    color: var(--sl-color-white);
-  }
+.sidebar-content a:hover,
+.sidebar-content a:focus {
+  color: var(--sl-color-white);
+}
 
-  .sidebar-content a[aria-current='page'],
-  .sidebar-content a[aria-current='page']:hover,
-  .sidebar-content a[aria-current='page']:focus {
-    font-weight: 600;
-    color: var(--sl-color-text-invert);
-    background-color: var(--sl-color-text-accent);
-  }
-  ```,
-)
+.sidebar-content a[aria-current='page'],
+.sidebar-content a[aria-current='page']:hover,
+.sidebar-content a[aria-current='page']:focus {
+  font-weight: 600;
+  color: var(--sl-color-text-invert);
+  background-color: var(--sl-color-text-accent);
+}
+```)

--- a/themes/starlight/page.typ
+++ b/themes/starlight/page.typ
@@ -10,8 +10,8 @@
       div(class: "sidebar-content sl-flex", include "page-sidebar.typ")
     })
   })
-  div(class: "main-frame", div.with(class: "lg:sl-flex")({
-    {
+  div.with(class: "main-frame")(
+    div.with(class: "lg:sl-flex")({
       if has-toc {
         h.aside.with(
           class: "right-sidebar-container",
@@ -24,108 +24,106 @@
       }
 
       div(class: "main-pane", include "page-main.typ")
-    }
-  }))
+    }),
+  )
 })
 
-#add-styles(
-  ```css
-  html:not([data-has-toc]) {
-    --sl-mobile-toc-height: 0rem;
+#stylesheet(key: "starlight", ```css
+html:not([data-has-toc]) {
+  --sl-mobile-toc-height: 0rem;
+}
+html:not([data-has-sidebar]) {
+  --sl-content-width: 67.5rem;
+}
+/* Add scroll padding to ensure anchor headings aren't obscured by nav */
+html {
+  /* Additional padding is needed to account for the mobile TOC */
+  scroll-padding-top: calc(1.5rem + var(--sl-nav-height) + var(--sl-mobile-toc-height));
+}
+main {
+  padding-bottom: 3vh;
+}
+@media (min-width: 50em) {
+  [data-has-sidebar] {
+    --sl-content-inline-start: var(--sl-sidebar-width);
   }
-  html:not([data-has-sidebar]) {
-    --sl-content-width: 67.5rem;
-  }
-  /* Add scroll padding to ensure anchor headings aren't obscured by nav */
+}
+@media (min-width: 72em) {
   html {
-    /* Additional padding is needed to account for the mobile TOC */
-    scroll-padding-top: calc(1.5rem + var(--sl-nav-height) + var(--sl-mobile-toc-height));
+    scroll-padding-top: calc(1.5rem + var(--sl-nav-height));
   }
-  main {
-    padding-bottom: 3vh;
+}
+
+@layer starlight.core {
+  .page {
+    flex-direction: column;
+    min-height: 100vh;
   }
-  @media (min-width: 50em) {
-    [data-has-sidebar] {
-      --sl-content-inline-start: var(--sl-sidebar-width);
-    }
+
+  .header {
+    z-index: var(--sl-z-index-navbar);
+    position: fixed;
+    inset-inline-start: 0;
+    inset-block-start: 0;
+    width: 100%;
+    height: var(--sl-nav-height);
+    border-bottom: 1px solid var(--sl-color-hairline-shade);
+    padding: var(--sl-nav-pad-y) var(--sl-nav-pad-x);
+    padding-inline-end: var(--sl-nav-pad-x);
+    background-color: var(--sl-color-bg-nav);
   }
-  @media (min-width: 72em) {
-    html {
-      scroll-padding-top: calc(1.5rem + var(--sl-nav-height));
+
+  :global([data-has-sidebar]) .header {
+    padding-inline-end: calc(
+      var(--sl-nav-gap) + var(--sl-nav-pad-x) + var(--sl-menu-button-size)
+    );
+  }
+
+  .sidebar-pane {
+    visibility: var(--sl-sidebar-visibility, hidden);
+    position: fixed;
+    z-index: var(--sl-z-index-menu);
+    inset-block: var(--sl-nav-height) 0;
+    inset-inline-start: 0;
+    width: 100%;
+    background-color: var(--sl-color-black);
+    overflow-y: auto;
+  }
+
+  [data-mobile-menu-expanded] .sidebar-pane {
+    --sl-sidebar-visibility: visible;
+  }
+
+  .sidebar-content {
+    height: 100%;
+    min-height: max-content;
+    padding: 1rem var(--sl-sidebar-pad-x) 0;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  @media (min-width: 50rem) {
+    .sidebar-content::after {
+      content: '';
+      padding-bottom: 1px;
     }
   }
 
-  @layer starlight.core {
-    .page {
-      flex-direction: column;
-      min-height: 100vh;
-    }
+  .main-frame {
+    padding-top: calc(var(--sl-nav-height) + var(--sl-mobile-toc-height));
+    padding-inline-start: var(--sl-content-inline-start);
+  }
 
-    .header {
-      z-index: var(--sl-z-index-navbar);
-      position: fixed;
-      inset-inline-start: 0;
-      inset-block-start: 0;
-      width: 100%;
-      height: var(--sl-nav-height);
-      border-bottom: 1px solid var(--sl-color-hairline-shade);
-      padding: var(--sl-nav-pad-y) var(--sl-nav-pad-x);
-      padding-inline-end: var(--sl-nav-pad-x);
-      background-color: var(--sl-color-bg-nav);
-    }
-
+  @media (min-width: 50rem) {
     :global([data-has-sidebar]) .header {
-      padding-inline-end: calc(
-        var(--sl-nav-gap) + var(--sl-nav-pad-x) + var(--sl-menu-button-size)
-      );
+      padding-inline-end: var(--sl-nav-pad-x);
     }
-
     .sidebar-pane {
-      visibility: var(--sl-sidebar-visibility, hidden);
-      position: fixed;
-      z-index: var(--sl-z-index-menu);
-      inset-block: var(--sl-nav-height) 0;
-      inset-inline-start: 0;
-      width: 100%;
-      background-color: var(--sl-color-black);
-      overflow-y: auto;
-    }
-
-    [data-mobile-menu-expanded] .sidebar-pane {
       --sl-sidebar-visibility: visible;
-    }
-
-    .sidebar-content {
-      height: 100%;
-      min-height: max-content;
-      padding: 1rem var(--sl-sidebar-pad-x) 0;
-      flex-direction: column;
-      gap: 1rem;
-    }
-
-    @media (min-width: 50rem) {
-      .sidebar-content::after {
-        content: '';
-        padding-bottom: 1px;
-      }
-    }
-
-    .main-frame {
-      padding-top: calc(var(--sl-nav-height) + var(--sl-mobile-toc-height));
-      padding-inline-start: var(--sl-content-inline-start);
-    }
-
-    @media (min-width: 50rem) {
-      :global([data-has-sidebar]) .header {
-        padding-inline-end: var(--sl-nav-pad-x);
-      }
-      .sidebar-pane {
-        --sl-sidebar-visibility: visible;
-        width: var(--sl-sidebar-width);
-        background-color: var(--sl-color-bg-sidebar);
-        border-inline-end: 1px solid var(--sl-color-hairline-shade);
-      }
+      width: var(--sl-sidebar-width);
+      background-color: var(--sl-color-bg-sidebar);
+      border-inline-end: 1px solid var(--sl-color-hairline-shade);
     }
   }
-  ```,
-)
+}
+```)

--- a/themes/starlight/site-search-results.typ
+++ b/themes/starlight/site-search-results.typ
@@ -4,7 +4,7 @@
 
 // ---
 
-#add-styles(raw(lang: "css", read("styles/search.css")))
+#stylesheet(key: "starlight", read("styles/search.css"))
 #inline-assets(raw(lang: "js", {
   "window.path_to_root = "
   json.encode(x-url-base)

--- a/themes/starlight/social-icons.typ
+++ b/themes/starlight/social-icons.typ
@@ -12,8 +12,8 @@
     })
   }
 
-  add-styles.with(cond: links.len() > 0)(
-    ```css
+  if links.len() > 0 {
+    stylesheet(key: "starlight", ```css
     @layer starlight.core {
       a.social-icon {
         color: var(--sl-color-text-accent);
@@ -24,6 +24,6 @@
         opacity: 0.66;
       }
     }
-    ```,
-  )
+    ```)
+  }
 }

--- a/themes/starlight/table-of-contents.typ
+++ b/themes/starlight/table-of-contents.typ
@@ -19,67 +19,65 @@
 })
 
 
-#add-styles(
-  ```css
-  @layer starlight.core {
-    .toc a {
-      display: block;
-      font-size: var(--sl-text-xs);
-      text-decoration: none;
-      color: var(--sl-color-gray-3);
-      overflow-wrap: anywhere;
-    }
-    .toc a:hover {
-      color: var(--sl-color-white);
-    }
-    ul.toc {
-      padding: 0;
-      list-style: none;
-    }
-    .toc a {
-      --pad-inline: 0.5rem;
-      display: block;
-      border-radius: 0.25rem;
-      padding-block: 0.25rem;
-      padding-inline: calc(1rem * var(--depth) + var(--pad-inline)) var(--pad-inline);
-      line-height: 1.25;
-    }
-    .toc a[aria-current='true'] {
-      color: var(--sl-color-text-accent);
-    }
-    .toc .isMobile a {
-      --pad-inline: 1rem;
-      display: flex;
-      justify-content: space-between;
-      gap: var(--pad-inline);
-      border-top: 1px solid var(--sl-color-gray-6);
-      border-radius: 0;
-      padding-block: 0.5rem;
-      color: var(--sl-color-text);
-      font-size: var(--sl-text-sm);
-      text-decoration: none;
-      outline-offset: var(--sl-outline-offset-inside);
-    }
-    .toc .isMobile:first-child > li:first-child > a {
-      border-top: 0;
-    }
-    .toc .isMobile a[aria-current='true'],
-    .toc .isMobile a[aria-current='true']:hover,
-    .toc .isMobile a[aria-current='true']:focus {
-      color: var(--sl-color-white);
-      background-color: unset;
-    }
-    .toc .isMobile a[aria-current='true']::after {
-      content: '';
-      width: 1rem;
-      background-color: var(--sl-color-text-accent);
-      /* Check mark SVG icon */
-      -webkit-mask-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNCAxNCc+PHBhdGggZD0nTTEwLjkxNCA0LjIwNmEuNTgzLjU4MyAwIDAgMC0uODI4IDBMNS43NCA4LjU1NyAzLjkxNCA2LjcyNmEuNTk2LjU5NiAwIDAgMC0uODI4Ljg1N2wyLjI0IDIuMjRhLjU4My41ODMgMCAwIDAgLjgyOCAwbDQuNzYtNC43NmEuNTgzLjU4MyAwIDAgMCAwLS44NTdaJy8+PC9zdmc+Cg==');
-      mask-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNCAxNCc+PHBhdGggZD0nTTEwLjkxNCA0LjIwNmEuNTgzLjU4MyAwIDAgMC0uODI4IDBMNS43NCA4LjU1NyAzLjkxNCA2LjcyNmEuNTk2LjU5NiAwIDAgMC0uODI4Ljg1N2wyLjI0IDIuMjRhLjU4My41ODMgMCAwIDAgLjgyOCAwbDQuNzYtNC43NmEuNTgzLjU4MyAwIDAgMCAwLS44NTdaJy8+PC9zdmc+Cg==');
-      -webkit-mask-repeat: no-repeat;
-      mask-repeat: no-repeat;
-      flex-shrink: 0;
-    }
+#stylesheet(key: "starlight", ```css
+@layer starlight.core {
+  .toc a {
+    display: block;
+    font-size: var(--sl-text-xs);
+    text-decoration: none;
+    color: var(--sl-color-gray-3);
+    overflow-wrap: anywhere;
   }
-  ```,
-)
+  .toc a:hover {
+    color: var(--sl-color-white);
+  }
+  ul.toc {
+    padding: 0;
+    list-style: none;
+  }
+  .toc a {
+    --pad-inline: 0.5rem;
+    display: block;
+    border-radius: 0.25rem;
+    padding-block: 0.25rem;
+    padding-inline: calc(1rem * var(--depth) + var(--pad-inline)) var(--pad-inline);
+    line-height: 1.25;
+  }
+  .toc a[aria-current='true'] {
+    color: var(--sl-color-text-accent);
+  }
+  .toc .isMobile a {
+    --pad-inline: 1rem;
+    display: flex;
+    justify-content: space-between;
+    gap: var(--pad-inline);
+    border-top: 1px solid var(--sl-color-gray-6);
+    border-radius: 0;
+    padding-block: 0.5rem;
+    color: var(--sl-color-text);
+    font-size: var(--sl-text-sm);
+    text-decoration: none;
+    outline-offset: var(--sl-outline-offset-inside);
+  }
+  .toc .isMobile:first-child > li:first-child > a {
+    border-top: 0;
+  }
+  .toc .isMobile a[aria-current='true'],
+  .toc .isMobile a[aria-current='true']:hover,
+  .toc .isMobile a[aria-current='true']:focus {
+    color: var(--sl-color-white);
+    background-color: unset;
+  }
+  .toc .isMobile a[aria-current='true']::after {
+    content: '';
+    width: 1rem;
+    background-color: var(--sl-color-text-accent);
+    /* Check mark SVG icon */
+    -webkit-mask-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNCAxNCc+PHBhdGggZD0nTTEwLjkxNCA0LjIwNmEuNTgzLjU4MyAwIDAgMC0uODI4IDBMNS43NCA4LjU1NyAzLjkxNCA2LjcyNmEuNTk2LjU5NiAwIDAgMC0uODI4Ljg1N2wyLjI0IDIuMjRhLjU4My41ODMgMCAwIDAgLjgyOCAwbDQuNzYtNC43NmEuNTgzLjU4MyAwIDAgMCAwLS44NTdaJy8+PC9zdmc+Cg==');
+    mask-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNCAxNCc+PHBhdGggZD0nTTEwLjkxNCA0LjIwNmEuNTgzLjU4MyAwIDAgMC0uODI4IDBMNS43NCA4LjU1NyAzLjkxNCA2LjcyNmEuNTk2LjU5NiAwIDAgMC0uODI4Ljg1N2wyLjI0IDIuMjRhLjU4My41ODMgMCAwIDAgLjgyOCAwbDQuNzYtNC43NmEuNTgzLjU4MyAwIDAgMCAwLS44NTdaJy8+PC9zdmc+Cg==');
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    flex-shrink: 0;
+  }
+}
+```)

--- a/themes/starlight/theme-select.typ
+++ b/themes/starlight/theme-select.typ
@@ -16,9 +16,8 @@
   })
 }
 
-#inline-assets({
-  ```js
-
+#static-asset(
+  text: ```js
   // type Theme = 'auto' | 'dark' | 'light';
 
   /** Key in `localStorage` to store color theme preference at. */
@@ -77,19 +76,12 @@
   });
 
   onThemeChange(loadTheme());
-  // this.querySelector('select')?.addEventListener('change', (e) => {
-  //   if (e.currentTarget instanceof HTMLSelectElement) {
-  //     onThemeChange(parseTheme(e.currentTarget.value));
-  //   }
-  // });
+  ```,
+  dest: "assets/theme-change.js",
+)
 
-
-
-  ```
-})
-
-#add-styles.with(cond: links.len() > 0)(
-  ```css
+#if links.len() > 0 {
+  stylesheet(key: "starlight", ```css
   @layer starlight.core {
     .theme-button {
       background: none;
@@ -104,5 +96,5 @@
       opacity: 0.66;
     }
   }
-  ```,
-)
+  ```)
+}


### PR DESCRIPTION
This PR introduces initial support for static assets. This can significantly reduce the size of the output HTML by avoiding inlining large assets.

The source can emit static assets with a `static-asset` function, which injects metadata for link generation in `<head>` and server-side asset handling. It can take path, text, or bytes as source input.

We also provide a utility function: `stylesheet(body, key, priority)`. Contents with the same key are merged by priority into one file, identified by `key`.

The mdbook theme has not changed yet.

For comparison, the dist size of shiroa docs reduces from 3.67 MiB to 2.87 MiB. With zebraw assets extraction, the size can be further reduced to 2.11 MiB.

## TODO

- Properly handle asset content conflicts. This can result from regular content update or inconsistent data provided from different pages.
- Watch asset dependency change. Ensure that updated assets (referenced by path) can be updated to the dist.
- Hot reload. Currently, when an asset file in the dist is modified, it is still cached in the browser. We need to manually trigger an update.
- Image support. This will not be included in this PR, but we should consider its API design.