### PR TITLE
fix: improve inline math baseline alignment for static-html mode

### DIFF
--- a/packages/shiroa/templates.typ
+++ b/packages/shiroa/templates.typ
@@ -149,6 +149,10 @@
     .inline-equation {
       display: inline-block;
       width: fit-content;
+      vertical-align: middle;
+      transform: translateY(-0.1em);
+      padding-top: 0.5em;
+      padding-bottom: 0.5em;
     }
     .block-equation {
       display: grid;


### PR DESCRIPTION
In [`static-html` build mode](https://myriad-dreamin.github.io/shiroa/cli/build.html#label---mode) with math-heavy content, inline SVG math
can appear misaligned relative to the surrounding text baseline.

A heuristic is added to `.inline-equation` to improve baseline alignment:

```css
.inline-equation {
    display: inline-block;
    width: fit-content;

    /* approximate allignment to baseline */
    vertical-align: middle;
    transform: translateY(-0.1em);
    padding-top: 0.5em;
    padding-bottom: 0.5em;
}
```

Before:
<img width="2504" height="1190" alt="Pasted image 20260224203431" src="https://github.com/user-attachments/assets/027e3846-7a22-477f-a8b0-c615b3b1dd22" />

After:
<img width="2504" height="1195" alt="Pasted image 20260224203453" src="https://github.com/user-attachments/assets/6df8b6c5-1098-42eb-bfa7-0b8578fb692a" />

