### PR TITLE
feat(cli): --input KEY=VALUE passthrough to sys.inputs

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -78,6 +78,12 @@ pub enum RenderMode {
 
 const ENV_PATH_SEP: char = if cfg!(windows) { ';' } else { ':' };
 
+fn parse_input_pair(raw: &str) -> Result<(String, String), String> {
+    raw.split_once('=')
+        .map(|(k, v)| (k.to_owned(), v.to_owned()))
+        .ok_or_else(|| "must be key=value".into())
+}
+
 #[derive(Default, Debug, Clone, Parser)]
 #[clap(next_help_heading = "Compile options")]
 pub struct CompileArgs {
@@ -119,6 +125,16 @@ pub struct CompileArgs {
         value_delimiter = ENV_PATH_SEP
     )]
     pub font_paths: Vec<PathBuf>,
+
+    /// Add a string key-value pair visible through `sys.inputs`. Mirrors
+    /// `typst compile --input`.
+    #[clap(
+        long = "input",
+        value_name = "key=value",
+        action = clap::ArgAction::Append,
+        value_parser = parse_input_pair,
+    )]
+    pub inputs: Vec<(String, String)>,
 
     /// Output to directory, default in the same directory as the entry file.
     /// Relative paths are interpreted relative to the book's root directory.

--- a/cli/src/render/typst.rs
+++ b/cli/src/render/typst.rs
@@ -103,6 +103,7 @@ impl TypstRenderer {
             ctx: RenderContext {
                 output: dest_dir.clone(),
                 url_base: args.path_to_root.into(),
+                extra_inputs: args.inputs,
                 compiler,
                 root_dir,
                 dest_dir,
@@ -163,6 +164,9 @@ impl TypstRenderer {
                 dict.insert("x-target".into(), ctx.compiler.target.clone().into_value());
                 let current = unix_slash(&Path::new("/").join(path)).into_value();
                 dict.insert("x-current".into(), current);
+                for (k, v) in &self.ctx.extra_inputs {
+                    dict.insert(k.as_str().into(), v.clone().into_value());
+                }
                 Arc::new(LazyHash::new(dict))
             }),
         };
@@ -304,6 +308,7 @@ impl TypstRenderer {
 pub struct RenderContext {
     pub extension: EcoString,
     pub url_base: EcoString,
+    pub extra_inputs: Vec<(String, String)>,
     pub output: PathBuf,
     pub compiler: ExportDynSvgModuleTask,
     pub root_dir: PathBuf,


### PR DESCRIPTION
Mirrors `typst compile --input`: each `--input k=v` becomes a string entry in `sys.inputs`, alongside the `x-*` keys shiroa already sets.

Lets book chapters read build-time values (git sha, env name, etc.) the same way they would under bare `typst compile`, e.g.:

```typst
#let rev = sys.inputs.at("git-sha", default: "main")
```

```sh
shiroa build --input git-sha=$(git rev-parse HEAD) ...
```