### PR TITLE
feat(serve): don't clobber full searchindex with partial on increments

### DIFF
--- a/cli/src/project/watch.rs
+++ b/cli/src/project/watch.rs
@@ -137,7 +137,18 @@ impl Project {
             }
 
             // todo: blocking?
-            let _ = self.compile_once(&active_files, SearchRenderer::new());
+            // The cold-start `self.build()` above already wrote a full
+            // searchindex (empty filter → every chapter). Here we only
+            // compile the held/changed chapters, so the index built from
+            // this pass would be partial. Suppress the index write so we
+            // don't clobber the full one. Tradeoff: search doesn't reflect
+            // edits during a serve session — restart (or `shiroa build`)
+            // to refresh.
+            let _ = self.compile_once(&active_files, {
+                let mut sr = SearchRenderer::new();
+                sr.config.copy_js = false;
+                sr
+            });
 
             if !is_heartbeat {
                 let _ = tx.send(WatchSignal::Reload);


### PR DESCRIPTION
The cold-start `build()` writes a full searchindex (empty filter → all chapters render). The watch loop then recompiles only the held/changed chapters on each `HoldPath`/`Fs` event, but passed a fresh `SearchRenderer` with `copy_js=true` — so each iteration overwrote `searchindex.json` with a partial index built from only the active set.

In practice the first browser page-load reduces the index to one document, and every edit shrinks it to whatever's currently held. `shiroa build` is unaffected (no watch loop).

This sets `copy_js=false` in the watch loop's renderer so the full cold-start index stays intact. Tradeoff: search doesn't reflect edits during a serve session — restart to refresh.