### PR TITLE
fix: use html std key for html target detection

### DIFF
--- a/contrib/typst/gh-pages.typ
+++ b/contrib/typst/gh-pages.typ
@@ -16,7 +16,7 @@
 #let is-html-target = is-html-target()
 #let is-pdf-target = is-pdf-target()
 #let is-web-target = is-web-target()
-#let sys-is-html-target = ("target" in dictionary(std))
+#let sys-is-html-target = ("html" in dictionary(std))
 
 // Theme (Colors)
 #let themes = theme-box-styles-from(toml("theme-style.toml"), read: it => read(it))

--- a/packages/shiroa/meta-and-state.typ
+++ b/packages/shiroa/meta-and-state.typ
@@ -25,7 +25,7 @@
 #let book-sys = (
   target: x-target,
   page-width: page-width,
-  sys-is-html-target: ("target" in dictionary(std)),
+  sys-is-html-target: ("html" in dictionary(std)),
   is-html-target: is-html-target(),
   is-web-target: is-web-target(),
   is-pdf-target: is-pdf-target(),

--- a/packages/shiroa/template-theme.typ
+++ b/packages/shiroa/template-theme.typ
@@ -78,7 +78,7 @@
   light-theme: none,
   dark-theme: none,
 ) = {
-  let sys-is-html-target = ("target" in dictionary(std))
+  let sys-is-html-target = ("html" in dictionary(std))
 
   if light-theme == none {
     for (name, it) in preset.pairs() {
@@ -124,7 +124,7 @@
     default-theme: default-theme,
   ) = themes
   let is-md-target = target == "md"
-  let sys-is-html-target = ("target" in dictionary(std))
+  let sys-is-html-target = ("html" in dictionary(std))
 
   if is-md-target {
     show: html.elem.with(tag)


### PR DESCRIPTION
- detect Typst HTML support with `html` in `std` instead of `target`
- update gh-pages template and shiroa theme/meta helpers for Typst v0.15.0 compatibility
