### PR TITLE
build: improve cargo-dist cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Myriad-Dreamin/cargo-dist/releases/download/v0.32.0-tinymist.2/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Myriad-Dreamin/cargo-dist/releases/download/v0.32.0-tinymist.5/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v7
         with:
@@ -161,6 +161,11 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - uses: swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ join(matrix.targets, '-') }}
+          cache-provider: ${{ matrix.cache_provider }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,9 +4,9 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.32.0-tinymist.2"
+cargo-dist-version = "0.32.0-tinymist.5"
 # A URL to use to install `cargo-dist` (with the installer script)
-cargo-dist-url-override = "https://github.com/Myriad-Dreamin/cargo-dist/releases/download/v0.32.0-tinymist.2"
+cargo-dist-url-override = "https://github.com/Myriad-Dreamin/cargo-dist/releases/download/v0.32.0-tinymist.5"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
@@ -50,6 +50,8 @@ dispatch-releases = true
 install-updater = false
 # Path that installers should place binaries in
 install-path = ["$XDG_BIN_HOME/", "$XDG_DATA_HOME/../bin", "~/.local/bin"]
+# Whether to cache builds
+cache-builds = true
 
 [dist.github-custom-runners]
 global = "ubuntu-22.04"


### PR DESCRIPTION
- upgrade cargo-dist from 0.32.0-tinymist.2 to 0.32.0-tinymist.5
- enable cargo-dist build caching for release matrix jobs
- regenerate the release workflow so CI keeps targeted builds and uses shared rust-cache keys
