### PR TITLE
fix: meta title when site title is missing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,11 @@ jobs:
       - name: Test CLI (Build Html Minimal)
         run: cargo run --release --bin shiroa -- build --mode static-html
         working-directory: tests/minimal
+      - name: Test CLI (Build Html Missing Site Title)
+        run: |
+          cargo run --release --bin shiroa -- build --mode static-html
+          grep -F '<title>Page Only</title>' dist/chapter.html
+        working-directory: tests/missing-site-title
 
   build:
     permissions:

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -54,6 +54,7 @@ const versionFiles = [
 
 const changelog = inspectChangelog(changelogPath, releaseVersion, previousStableTag);
 const draftRelease = inspectDraftReleaseScript();
+const releaseNotes = inspectReleaseNotes(changelogPath, targetVersion);
 const cargoDependencyCheck = inspectCargoDependencyPins();
 
 const blockers = [
@@ -65,6 +66,7 @@ const blockers = [
         : [`current branch is ${currentBranch}, expected ${expectedBranch}`]),
     ...changelog.blockers,
     ...draftRelease.blockers,
+    ...releaseNotes.blockers,
     ...cargoDependencyCheck.blockers,
 ];
 
@@ -82,6 +84,7 @@ const result = {
     typstPackageVersions,
     changelog,
     draftRelease,
+    releaseNotes,
     cargoDependencyCheck,
     commands: buildCommands(targetVersion, targetTag, expectedBranch, changelogPath),
     readiness: {
@@ -94,6 +97,10 @@ if (outputJson) {
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 } else {
     printHuman(result);
+}
+
+if (!result.readiness.ready) {
+    process.exitCode = 1;
 }
 
 function usage(message) {
@@ -256,6 +263,82 @@ function inspectDraftReleaseScript() {
     };
 }
 
+function inspectReleaseNotes(changelogPath, targetVersion) {
+    const blockers = [];
+    const expectedCompareSuffix = `...v${targetVersion}`;
+    let body = '';
+    let fullChangelogLine = null;
+
+    if (!fs.existsSync(changelogPath)) {
+        return {
+            ready: false,
+            source: changelogPath,
+            expectedCompareSuffix,
+            fullChangelogLine,
+            blockers: [`cannot generate release notes because ${changelogPath} is missing`],
+        };
+    }
+
+    try {
+        const changelogPlainRaw = execFileSync('parse-changelog', [changelogPath], {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        body = patchFullChangelogLine(changelogPlainRaw, targetVersion);
+    } catch (error) {
+        blockers.push(`failed to generate release notes from ${changelogPath}: ${error.message}`);
+    }
+
+    if (!body.trim()) {
+        blockers.push(`generated release notes from ${changelogPath} are empty`);
+    }
+
+    if (/^\s*Release candidate for v\d+\.\d+\.\d+\.\s*$/m.test(body)) {
+        blockers.push('generated release notes still use the placeholder release-candidate body');
+    }
+
+    fullChangelogLine = body
+        .split('\n')
+        .find((line) => line.startsWith('**Full Changelog**:')) ?? null;
+
+    if (!fullChangelogLine) {
+        blockers.push('generated release notes are missing a **Full Changelog** line');
+    } else if (!fullChangelogLine.includes(expectedCompareSuffix)) {
+        blockers.push(`generated release notes full changelog line must end at v${targetVersion}`);
+    }
+
+    return {
+        ready: blockers.length === 0,
+        source: changelogPath,
+        expectedCompareSuffix,
+        fullChangelogLine,
+        blockers,
+    };
+}
+
+function patchFullChangelogLine(changelogPlainRaw, targetVersion) {
+    const fullChangelogLine =
+        /\*\*Full Changelog\*\*: https:\/\/github.com\/Myriad-Dreamin\/shiroa\/compare\/v(\d+\.\d+\.\d+)...v(\d+\.\d+\.\d+)/;
+    let anyMatched = false;
+
+    const patched = changelogPlainRaw.replace(fullChangelogLine, (_match, previousVersion, releaseVersion) => {
+        anyMatched = true;
+        if (!targetVersion.startsWith(releaseVersion)) {
+            throw new Error(
+                `expected target version ${targetVersion} to start with changelog release version ${releaseVersion}`,
+            );
+        }
+
+        return `**Full Changelog**: https://github.com/Myriad-Dreamin/shiroa/compare/v${previousVersion}...v${targetVersion}`;
+    });
+
+    if (!anyMatched) {
+        throw new Error('failed to patch the full changelog link');
+    }
+
+    return patched;
+}
+
 function inspectCargoDependencyPins() {
     const files = ['Cargo.toml', 'cli/Cargo.toml', 'tools/build-from-source/Cargo.toml'];
     const blockers = [];
@@ -348,6 +431,11 @@ function printHuman(data) {
     for (const item of data.typstPackageVersions) {
         console.log(`- ${item.path}: ${item.version ?? '(unknown)'}`);
     }
+
+    console.log('');
+    console.log('Release notes:');
+    console.log(`- source: ${data.releaseNotes.source}`);
+    console.log(`- Full Changelog: ${data.releaseNotes.fullChangelogLine ?? '(missing)'}`);
 
     console.log('');
     if (data.readiness.ready) {

--- a/tests/missing-site-title/book.typ
+++ b/tests/missing-site-title/book.typ
@@ -1,0 +1,11 @@
+#import "@preview/shiroa:0.4.0": *
+#show: book
+
+#book-meta(
+  authors: ("shiroa",),
+  language: "en",
+  summary: [
+    = Missing Site Title
+    - #chapter("chapter.typ", section: "1")[Page Only]
+  ],
+)

--- a/tests/missing-site-title/chapter.typ
+++ b/tests/missing-site-title/chapter.typ
@@ -1,0 +1,7 @@
+#import "template.typ": *
+
+#show: project.with(title: "Page Only")
+
+= Page Only
+
+This fixture intentionally omits `book-meta.title`.

--- a/tests/missing-site-title/template.typ
+++ b/tests/missing-site-title/template.typ
@@ -1,0 +1,25 @@
+#import "@preview/shiroa:0.4.0": get-page-width, is-html-target, is-pdf-target, is-web-target, templates, x-target
+#import templates: *
+
+#let project(title: "Page Only", body) = {
+  set page(
+    width: get-page-width(),
+    height: auto,
+  ) if is-pdf-target() or is-web-target()
+
+  let web-theme = if x-target.starts-with("html") and not x-target.starts-with("html-wrapper") {
+    "starlight"
+  } else {
+    "mdbook"
+  }
+
+  show: if web-theme == "starlight" {
+    import "@preview/shiroa-starlight:0.4.0": starlight
+    starlight.with(include "book.typ", title: title)
+  } else {
+    import "@preview/shiroa-mdbook:0.4.0": mdbook
+    mdbook.with(include "book.typ", title: title)
+  }
+
+  body
+}

--- a/themes/mdbook/lib.typ
+++ b/themes/mdbook/lib.typ
@@ -9,6 +9,45 @@
   if discord != none { ((href: discord, label: "Discord", icon: "discord"),) }
 }
 
+#let title-text(it) = {
+  import "@preview/shiroa:0.4.0": plain-text
+  if it == none {
+    ""
+  } else {
+    plain-text(it).trim()
+  }
+}
+
+#let default-meta-title(title, site-title) = {
+  let title = title-text(title)
+  let site-title = title-text(site-title)
+  if title != "" and site-title != "" {
+    title-text([#title -- #site-title])
+  } else if title != "" {
+    title
+  } else if site-title != "" {
+    site-title
+  } else {
+    ""
+  }
+}
+
+#let book-site-title(it) = {
+  let title = ""
+  if it != none {
+    if "raw-title" in it {
+      title = if it.raw-title == none { "" } else { it.raw-title }
+    } else if "title" in it {
+      title = if type(it.title) == str {
+        it.title
+      } else {
+        it.title.content
+      }
+    }
+  }
+  title
+}
+
 #let mdbook(
   book,
   body,
@@ -17,11 +56,11 @@
   plain-body: auto,
   enable-search: true,
   extra-assets: (),
-  meta-title: (title, site-title) => if title != "" [#title -- #site-title] else { site-title },
+  meta-title: default-meta-title,
   social-links: social-links,
   right-group: none,
 ) = {
-  import "@preview/shiroa:0.4.0": get-book-meta, is-html-target, paged-load-trampoline, prepare-description, x-current, x-target, x-url-base
+  import "@preview/shiroa:0.4.0": get-book-meta, is-html-target, paged-load-trampoline, plain-text, prepare-description, x-current, x-target, x-url-base
   import "mod.typ": inline-assets, replace-raw
   import "html.typ": a, div, meta
   import "icons.typ": builtin-icon
@@ -37,23 +76,16 @@
   let plain-body = if plain-body == auto { body } else { plain-body }
   let description = prepare-description(description, plain-body: plain-body)
 
-  let site-title() = get-book-meta(mapper: it => if it != none {
-    if "raw-title" in it {
-      it.raw-title
-    } else if "title" in it {
-      if type(it.title) == str {
-        it.title
-      } else {
-        it.title.content
-      }
-    }
-  })
+  let site-title() = get-book-meta(mapper: book-site-title)
 
   // import "html-bindings-h.typ": span
 
   show: set-slot("sa:head-meta", {
     // <meta title>
-    context html.elem("title", meta-title(title, site-title()))
+    get-book-meta(mapper: it => {
+      let resolved-site-title = book-site-title(it)
+      html.elem("title", plain-text(meta-title(title, resolved-site-title)).trim())
+    })
     // <meta description>
     if description != none { meta(name: "description", content: description) }
   })

--- a/themes/starlight/lib.typ
+++ b/themes/starlight/lib.typ
@@ -11,6 +11,45 @@
   if discord != none { ((href: discord, label: "Discord", icon: "discord"),) }
 }
 
+#let title-text(it) = {
+  import "@preview/shiroa:0.4.0": plain-text
+  if it == none {
+    ""
+  } else {
+    plain-text(it).trim()
+  }
+}
+
+#let default-meta-title(title, site-title) = {
+  let title = title-text(title)
+  let site-title = title-text(site-title)
+  if title != "" and site-title != "" {
+    title-text([#title -- #site-title])
+  } else if title != "" {
+    title
+  } else if site-title != "" {
+    site-title
+  } else {
+    ""
+  }
+}
+
+#let book-site-title(it) = {
+  let title = ""
+  if it != none {
+    if "raw-title" in it {
+      title = if it.raw-title == none { "" } else { it.raw-title }
+    } else if "title" in it {
+      title = if type(it.title) == str {
+        it.title
+      } else {
+        it.title.content
+      }
+    }
+  }
+  title
+}
+
 #let starlight(
   book,
   body,
@@ -19,7 +58,7 @@
   plain-body: auto,
   enable-search: true,
   extra-assets: (),
-  meta-title: (title, site-title) => if title != "" [#title -- #site-title] else { site-title },
+  meta-title: default-meta-title,
   social-links: social-links,
   social-icons: {
     import "social-icons.typ": social-icons
@@ -27,7 +66,7 @@
   },
   right-group: none,
 ) = {
-  import "@preview/shiroa:0.4.0": get-book-meta, is-html-target, paged-load-trampoline, prepare-description, x-current, x-target
+  import "@preview/shiroa:0.4.0": get-book-meta, is-html-target, paged-load-trampoline, plain-text, prepare-description, x-current, x-target
   import "html.typ": inline-assets, meta, span
   import "mod.typ": replace-raw
 
@@ -42,17 +81,7 @@
   let plain-body = if plain-body == auto { body } else { plain-body }
   let description = prepare-description(description, plain-body: plain-body)
 
-  let site-title() = get-book-meta(mapper: it => if it != none {
-    if "raw-title" in it {
-      it.raw-title
-    } else if "title" in it {
-      if type(it.title) == str {
-        it.title
-      } else {
-        it.title.content
-      }
-    }
-  })
+  let site-title() = get-book-meta(mapper: book-site-title)
 
   let default-right-group() = get-book-meta(mapper: it => if it != none {
     let github-link = it.at("repository", default: none)
@@ -65,7 +94,10 @@
 
   show: set-slot("sa:head-meta", {
     // <meta title>
-    context html.elem("title", meta-title(title, site-title()))
+    get-book-meta(mapper: it => {
+      let resolved-site-title = book-site-title(it)
+      html.elem("title", plain-text(meta-title(title, resolved-site-title)).trim())
+    })
     // <meta description>
     if description != none { meta(name: "description", content: description) }
   })


### PR DESCRIPTION
- Treat missing or empty site titles as empty strings when building theme meta titles.
- Ensure HTML <title> output is plain text for mdbook and starlight themes.
- Add a static HTML regression fixture for books without book-meta.title.