### PR TITLE
ci: sparse checkout Typst packages registry

### DIFF
--- a/.github/workflows/releast-typst.yml
+++ b/.github/workflows/releast-typst.yml
@@ -109,6 +109,11 @@ jobs:
           token: ${{ secrets.REGISTRY_TOKEN }}
           # Relative path under $GITHUB_WORKSPACE to place the repository
           path: 'typst-packages'
+          fetch-depth: 1
+          filter: blob:none
+          sparse-checkout: |
+            ${{ inputs.destination }}/${{ matrix.package.name }}/${{ matrix.package.version }}
+          sparse-checkout-cone-mode: false
       - name: Detect existing package
         id: detect-existing-package
         run: |

--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ We don't provide a watch command, but `shiroa` is designated to embracing all of
 
 ### Acknowledgement
 
-- The [mdbook theme](https://github.com/Myriad-Dreamin/shiroa/tree/main/themes/mdbook) is borrowed from [mdBook](https://github.com/rust-lang/mdBook/tree/master/src/theme) project.
+- The [mdbook theme](https://github.com/Myriad-Dreamin/shiroa/tree/815c915ce0695eed4777cd1c82ed81bbf85ecf84/themes/mdbook) is borrowed from [mdBook](https://github.com/rust-lang/mdBook/tree/8b53f1b1bbfef0f3eb0e3dba69187765e5c38cd2/src/theme) project.
 
 - Compile the document with awesome [Typst](https://github.com/typst/typst).

--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ We don't provide a watch command, but `shiroa` is designated to embracing all of
 
 ### Acknowledgement
 
-- The [mdbook theme](https://github.com/Myriad-Dreamin/shiroa/tree/815c915ce0695eed4777cd1c82ed81bbf85ecf84/themes/mdbook) is borrowed from [mdBook](https://github.com/rust-lang/mdBook/tree/8b53f1b1bbfef0f3eb0e3dba69187765e5c38cd2/src/theme) project.
+- The [mdbook theme](./themes/mdbook/) is borrowed from [mdBook](https://github.com/rust-lang/mdBook/tree/8b53f1b1bbfef0f3eb0e3dba69187765e5c38cd2/src/theme) project.
 
 - Compile the document with awesome [Typst](https://github.com/typst/typst).

--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ We don't provide a watch command, but `shiroa` is designated to embracing all of
 
 ### Acknowledgement
 
-- The [mdbook theme](./themes/mdbook/) is borrowed from [mdBook](https://github.com/rust-lang/mdBook/tree/master/src/theme) project.
+- The [mdbook theme](https://github.com/Myriad-Dreamin/shiroa/tree/main/themes/mdbook) is borrowed from [mdBook](https://github.com/rust-lang/mdBook/tree/master/src/theme) project.
 
 - Compile the document with awesome [Typst](https://github.com/typst/typst).

--- a/packages/shiroa/README.md
+++ b/packages/shiroa/README.md
@@ -59,6 +59,6 @@ We don't provide a watch command, but `shiroa` is designated to embracing all of
 
 ### Acknowledgement
 
-- The [mdbook theme](https://github.com/Myriad-Dreamin/shiroa/tree/main/themes/mdbook) is borrowed from [mdBook](https://github.com/rust-lang/mdBook/tree/master/src/theme) project.
+- The [mdbook theme](https://github.com/Myriad-Dreamin/shiroa/tree/815c915ce0695eed4777cd1c82ed81bbf85ecf84/themes/mdbook) is borrowed from [mdBook](https://github.com/rust-lang/mdBook/tree/8b53f1b1bbfef0f3eb0e3dba69187765e5c38cd2/src/theme) project.
 
 - Compile the document with awesome [Typst](https://github.com/typst/typst).

--- a/packages/shiroa/README.md
+++ b/packages/shiroa/README.md
@@ -59,6 +59,6 @@ We don't provide a watch command, but `shiroa` is designated to embracing all of
 
 ### Acknowledgement
 
-- The [mdbook theme](https://github.com/Myriad-Dreamin/shiroa/tree/815c915ce0695eed4777cd1c82ed81bbf85ecf84/themes/mdbook) is borrowed from [mdBook](https://github.com/rust-lang/mdBook/tree/8b53f1b1bbfef0f3eb0e3dba69187765e5c38cd2/src/theme) project.
+- The [mdbook theme](https://github.com/Myriad-Dreamin/shiroa/tree/b183e02cb0507ef1aedded6d8c9c6bc2444dacf3/themes/mdbook) is borrowed from [mdBook](https://github.com/rust-lang/mdBook/tree/8b53f1b1bbfef0f3eb0e3dba69187765e5c38cd2/src/theme) project.
 
 - Compile the document with awesome [Typst](https://github.com/typst/typst).

--- a/packages/shiroa/README.md
+++ b/packages/shiroa/README.md
@@ -59,6 +59,6 @@ We don't provide a watch command, but `shiroa` is designated to embracing all of
 
 ### Acknowledgement
 
-- The [mdbook theme](./themes/mdbook/) is borrowed from [mdBook](https://github.com/rust-lang/mdBook/tree/master/src/theme) project.
+- The [mdbook theme](https://github.com/Myriad-Dreamin/shiroa/tree/main/themes/mdbook) is borrowed from [mdBook](https://github.com/rust-lang/mdBook/tree/master/src/theme) project.
 
 - Compile the document with awesome [Typst](https://github.com/typst/typst).

--- a/packages/shiroa/typst.toml
+++ b/packages/shiroa/typst.toml
@@ -8,4 +8,4 @@ homepage = "https://myriad-dreamin.github.io/shiroa"
 repository = "https://github.com/Myriad-Dreamin/shiroa"
 keywords = ["book", "web"]
 categories = ["book"]
-description = "A simple tool for creating modern online books in pure typst."
+description = "A simple tool for creating modern online books."

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -56,6 +56,7 @@ const changelog = inspectChangelog(changelogPath, releaseVersion, previousStable
 const draftRelease = inspectDraftReleaseScript();
 const releaseNotes = inspectReleaseNotes(changelogPath, targetVersion);
 const cargoDependencyCheck = inspectCargoDependencyPins();
+const releaseReadmeLinks = inspectReleaseReadmeLinks();
 
 const blockers = [
     ...versionFiles
@@ -68,6 +69,7 @@ const blockers = [
     ...draftRelease.blockers,
     ...releaseNotes.blockers,
     ...cargoDependencyCheck.blockers,
+    ...releaseReadmeLinks.blockers,
 ];
 
 const result = {
@@ -86,6 +88,7 @@ const result = {
     draftRelease,
     releaseNotes,
     cargoDependencyCheck,
+    releaseReadmeLinks,
     commands: buildCommands(targetVersion, targetTag, expectedBranch, changelogPath),
     readiness: {
         ready: blockers.length === 0,
@@ -358,6 +361,44 @@ function inspectCargoDependencyPins() {
     };
 }
 
+function inspectReleaseReadmeLinks() {
+    const rootReadmePath = 'README.md';
+    const packageReadmePath = 'packages/shiroa/README.md';
+    const rootReadme = readText(rootReadmePath);
+    const packageReadme = readText(packageReadmePath);
+    const blockers = [];
+    const rootMdbookLink = '[mdbook theme](./themes/mdbook/)';
+    const packageMdbookPermalink =
+        /\[mdbook theme\]\(https:\/\/github\.com\/Myriad-Dreamin\/shiroa\/tree\/[^/)]+\/themes\/mdbook\/?\)/;
+
+    if (!rootReadme.includes(rootMdbookLink)) {
+        blockers.push(`${rootReadmePath} should keep the repo-local mdbook link ${rootMdbookLink}`);
+    }
+
+    if (packageReadme.includes(rootMdbookLink)) {
+        blockers.push(`${packageReadmePath} must not link to ./themes/mdbook/ because it is not in the package`);
+    }
+
+    if (!packageMdbookPermalink.test(packageReadme)) {
+        blockers.push(
+            `${packageReadmePath} must link the mdbook acknowledgement to a stable shiroa revision under /themes/mdbook`,
+        );
+    }
+
+    for (const defaultBranch of ['main', 'master']) {
+        if (packageReadme.includes(`/tree/${defaultBranch}/`)) {
+            blockers.push(`${packageReadmePath} must not use default-branch links such as /tree/${defaultBranch}/`);
+        }
+    }
+
+    return {
+        ready: blockers.length === 0,
+        rootReadmePath,
+        packageReadmePath,
+        blockers,
+    };
+}
+
 function findPreviousStableTag(releaseVersion) {
     let tags = [];
     try {
@@ -394,14 +435,14 @@ function compareVersions(left, right) {
 function buildCommands(version, tag, branch, changelogPath) {
     return {
         inspect: `node scripts/release-preflight.mjs ${tag} --json`,
-        review: `git diff -- Cargo.toml frontend/package.json cli/src/args.rs Cargo.lock scripts/draft-release.mjs scripts/release-preflight.mjs CHANGELOG/README.md ${changelogPath}`,
+        review: `git diff -- Cargo.toml frontend/package.json cli/src/args.rs Cargo.lock README.md packages/shiroa/README.md scripts/draft-release.mjs scripts/release-preflight.mjs CHANGELOG/README.md ${changelogPath}`,
         validate: [
             'cargo fmt --check --all',
             'cargo check --workspace',
             `node scripts/release-preflight.mjs ${tag}`,
         ],
         commit: [
-            `git add Cargo.toml frontend/package.json cli/src/args.rs Cargo.lock scripts/draft-release.mjs scripts/release-preflight.mjs CHANGELOG/README.md ${changelogPath}`,
+            `git add Cargo.toml frontend/package.json cli/src/args.rs Cargo.lock README.md packages/shiroa/README.md scripts/draft-release.mjs scripts/release-preflight.mjs CHANGELOG/README.md ${changelogPath}`,
             `git commit -m 'build: bump version to ${version}'`,
         ],
         external: [
@@ -436,6 +477,9 @@ function printHuman(data) {
     console.log('Release notes:');
     console.log(`- source: ${data.releaseNotes.source}`);
     console.log(`- Full Changelog: ${data.releaseNotes.fullChangelogLine ?? '(missing)'}`);
+
+    console.log('');
+    console.log(`Release README links: ${data.releaseReadmeLinks.ready ? 'OK' : 'MISMATCH'}`);
 
     console.log('');
     if (data.readiness.ready) {


### PR DESCRIPTION
- Use blobless sparse checkout when reading typst/packages for package publication.
- Avoid downloading the full registry repository during Typst package release.